### PR TITLE
Const declaration should be valid in version 1.1

### DIFF
--- a/src/test/java/util/SuiteOps.java
+++ b/src/test/java/util/SuiteOps.java
@@ -14,10 +14,15 @@ import java.util.stream.Stream;
 public class SuiteOps {
 
     public static List<Object[]> reversion(String version, List<Object[]> files) {
-        return files.stream().map(obj -> {
-           var copy = Arrays.stream(obj).toArray(Object[]::new);
-           copy[0] = version;
-           return copy;
+      return files.stream()
+        .filter(obj -> {
+          File file = (File) obj[1];
+          return !file.getName().equals("invalid-const-declaration.ps");
+        })
+        .map(obj -> {
+          var copy = Arrays.stream(obj).toArray(Object[]::new);
+          copy[0] = version;
+          return copy;
         }).toList();
     }
 

--- a/src/test/resources/validation/1.1/invalid-const-declaration.ps
+++ b/src/test/resources/validation/1.1/invalid-const-declaration.ps
@@ -1,1 +1,0 @@
-const a: string = "constant declaration should not be allowed in version 1.0";


### PR DESCRIPTION
La const declaration no deberia ser tomada como invalida en la version 1.1. 
En los tests vuelve aplicar todos los casos del 1.0 en el 1.1 y agrega algunos mas, pero no saca el caso en el que se toma como invalido el const declaration